### PR TITLE
Feature/fkf.sp dev

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: FKF.SP
 Title: Fast Kalman Filtering Through Sequential Processing
-Version: 0.3.3
+Version: 0.3.4
 Authors@R: c(person("Thomas", "Aspinall", email = "tomaspinall2512@gmail.com", 
          role = c("aut", "cre"),
          comment = c(ORCID = "0000-0002-6968-1989")),

--- a/src/fkfs_SP.c
+++ b/src/fkfs_SP.c
@@ -70,7 +70,7 @@ void cfkfs_SP(
     // Save Z_SP for all observations:
     double *Z_SP = malloc(sizeof(double) * (m * d * n));
     // Save the total number of observations at every t:
-    double *d_t = malloc(sizeof(double) * n);
+    int *d_t = malloc(sizeof(int) * n);
 
     // SEQUENTIAL PROCESSING DEFINED VARIABLES:
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -5,8 +5,13 @@
 #include <R_ext/BLAS.h>
 #include <R_ext/Lapack.h>
 
-#define M_PI 3.14159265358979323846
+#ifndef M_PI
+#define M_PI 3.141592653589793238462643383280
+#endif
+
+#ifndef USE_FC_LEN_T
 #define USE_FC_LEN_T
+#endif
 
 #ifndef FCONE
 #define FCONE


### PR DESCRIPTION
- Hotfix: correctly coercing `d_t` from an array of type `double` to an array of type `int`
- Warning: wrapping `utils.h` declarations in an #ifndef for additional compatibility with various systems
- Iterating FKF.SP module to 0.3.4